### PR TITLE
add g:autodirmake#msg_highlight variable

### DIFF
--- a/autoload/autodirmake.vim
+++ b/autoload/autodirmake.vim
@@ -9,16 +9,33 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 let g:autodirmake#is_confirm = get(g:, 'autodirmake#is_confirm', 1)
+let g:autodirmake#msg_highlight = get(g:, 'autodirmake#msg_highlight', 'None')
 
 
 function! autodirmake#make_dir(dir)
     if !isdirectory(a:dir)
-        if (g:autodirmake#is_confirm == 1 && input(printf('"%s" does not exist. Create? [y/N]', a:dir)) !~? '^y\%[es]$')
-            return
+        if s:confirm(a:dir)
+            call mkdir(iconv(a:dir, &encoding, &termencoding), 'p')
         endif
-
-        call mkdir(iconv(a:dir, &encoding, &termencoding), 'p')
     endif
+endfunction
+
+function! s:confirm(dir)
+    if !g:autodirmake#is_confirm
+        return 1
+    endif
+    let hl = g:autodirmake#msg_highlight
+    if hl !=# '' && hl !=# 'None'
+        execute 'echohl' hl
+    endif
+    try
+        let prompt = printf('"%s" does not exist. Create? [y/N]', a:dir)
+        return input(prompt) =~? '^y\%[es]$'
+    finally
+        if hl !=# '' && hl !=# 'None'
+            echohl None
+        endif
+    endtry
 endfunction
 
 


### PR DESCRIPTION
`input()`時のメッセージが書き込み時のメッセージ等と目で区別しづらかったので、
`g:autodirmake#msg_highlight`というグローバル変数を追加しました。
この変数に.vimrcで空文字かNone以外の文字列を入れるとメッセージが
そのハイライトグループでハイライトされます。
### 補足
- ついでに`input()`周りを関数化してしまったので行数がちょっと長くなっちゃってます…
- `:try`, `:finally`はユーザが`<C-c>`を押した時のためです。
