### PR TITLE
Abbr filepathファイルパスをコマンドラインに収まるようにいい感じに省略する

### DIFF
--- a/autoload/autodirmake.vim
+++ b/autoload/autodirmake.vim
@@ -12,6 +12,11 @@ let g:autodirmake#is_confirm = get(g:, 'autodirmake#is_confirm', 1)
 let g:autodirmake#msg_highlight = get(g:, 'autodirmake#msg_highlight', 'None')
 
 
+let s:V = vital#of('autodirmake')
+let s:Prelude = s:V.import('Prelude')
+unlet s:V
+
+
 function! autodirmake#make_dir(dir)
     if !isdirectory(a:dir)
         if s:confirm(a:dir)
@@ -29,8 +34,17 @@ function! s:confirm(dir)
         execute 'echohl' hl
     endif
     try
-        let prompt = printf('"%s" does not exist. Create? [y/N]', a:dir)
-        return input(prompt) =~? '^y\%[es]$'
+        let prompt = '"%s" does not exist. Create? [y/N]'
+        let maxlen = &columns - 1
+        let maxlen -= strlen(prompt) + 8    " %s(2) + cosmetic space(10)
+        let abbrdir = a:dir
+        if strlen(abbrdir) > maxlen
+            " footer_width: separator + filename
+            let footer_width = strlen(fnamemodify(a:dir, ':t')) + 1
+            let abbrdir = s:Prelude.truncate_skipping(
+            \           abbrdir, maxlen - 3, footer_width, '...')
+        endif
+        return input(printf(prompt, abbrdir)) =~? '^y\%[es]$'
     finally
         if hl !=# '' && hl !=# 'None'
             echohl None

--- a/autoload/vital.vim
+++ b/autoload/vital.vim
@@ -1,0 +1,12 @@
+function! vital#of(name)
+  let files = globpath(&runtimepath, 'autoload/vital/' . a:name . '.vital')
+  let file = split(files, "\n")
+  if empty(file)
+    throw 'vital: version file not found: ' . a:name
+  endif
+  let ver = readfile(file[0], 'b')
+  if empty(ver)
+    throw 'vital: invalid version file: ' . a:name
+  endif
+  return vital#_{substitute(ver[0], '\W', '', 'g')}#new()
+endfunction

--- a/autoload/vital/_autodirmake.vim
+++ b/autoload/vital/_autodirmake.vim
@@ -1,0 +1,304 @@
+let s:self_version = expand('<sfile>:t:r')
+
+" Note: The extra argument to globpath() was added in Patch 7.2.051.
+let s:globpath_third_arg = v:version > 702 || v:version == 702 && has('patch51')
+
+let s:loaded = {}
+
+function! s:import(name, ...)
+  let target = {}
+  let functions = []
+  for a in a:000
+    if type(a) == type({})
+      let target = a
+    elseif type(a) == type([])
+      let functions = a
+    endif
+    unlet a
+  endfor
+  let module = s:_import(a:name)
+  if empty(functions)
+    call extend(target, module, 'keep')
+  else
+    for f in functions
+      if has_key(module, f) && !has_key(target, f)
+        let target[f] = module[f]
+      endif
+    endfor
+  endif
+  return target
+endfunction
+
+function! s:load(...) dict
+  for arg in a:000
+    let [name; as] = type(arg) == type([]) ? arg[: 1] : [arg, arg]
+    let target = split(join(as, ''), '\W\+')
+    let dict = self
+    while 1 <= len(target)
+      let ns = remove(target, 0)
+      if !has_key(dict, ns)
+        let dict[ns] = {}
+      endif
+      if type(dict[ns]) == type({})
+        let dict = dict[ns]
+      else
+        unlet dict
+        break
+      endif
+    endwhile
+
+    if exists('dict')
+      call extend(dict, s:_import(name))
+    endif
+    unlet arg
+  endfor
+  return self
+endfunction
+
+function! s:unload()
+  let s:loaded = {}
+endfunction
+
+function! s:exists(name)
+  return s:_get_module_path(a:name) !=# ''
+endfunction
+
+function! s:search(pattern)
+  let paths = s:_vital_files(a:pattern)
+  let modules = sort(map(paths, 's:_file2module(v:val)'))
+  return s:_uniq(modules)
+endfunction
+
+function! s:expand_modules(entry, all)
+  if type(a:entry) == type([])
+    let candidates = s:_concat(map(copy(a:entry), 's:search(v:val)'))
+    if empty(candidates)
+      throw printf('vital: Any of module %s is not found', string(a:entry))
+    endif
+    if eval(join(map(copy(candidates), 'has_key(a:all, v:val)'), '+'))
+      let modules = []
+    else
+      let modules = [candidates[0]]
+    endif
+  else
+    let modules = s:search(a:entry)
+    if empty(modules)
+      throw printf('vital: Module %s is not found', a:entry)
+    endif
+  endif
+  call filter(modules, '!has_key(a:all, v:val)')
+  for module in modules
+    let a:all[module] = 1
+  endfor
+  return modules
+endfunction
+
+function! s:_import(name)
+  if type(a:name) == type(0)
+    return s:_build_module(a:name)
+  endif
+  let path = s:_get_module_path(a:name)
+  if path ==# ''
+    throw 'vital: module not found: ' . a:name
+  endif
+  let sid = s:_get_sid_by_script(path)
+  if !sid
+    try
+      execute 'source' fnameescape(path)
+    catch /^Vim\%((\a\+)\)\?:E484/
+      throw 'vital: module not found: ' . a:name
+    catch /^Vim\%((\a\+)\)\?:E127/
+      " Ignore.
+    endtry
+
+    let sid = s:_get_sid_by_script(path)
+  endif
+  return s:_build_module(sid)
+endfunction
+
+function! s:_get_module_path(name)
+  if s:_is_absolute_path(a:name) && filereadable(a:name)
+    return a:name
+  endif
+  if a:name ==# ''
+    let paths = [s:self_file]
+  elseif a:name =~# '\v^\u\w*%(\.\u\w*)*$'
+    let paths = s:_vital_files(a:name)
+  else
+    throw 'vital: Invalid module name: ' . a:name
+  endif
+
+  call filter(paths, 'filereadable(expand(v:val))')
+  let path = get(paths, 0, '')
+  return path !=# '' ? path : ''
+endfunction
+
+function! s:_get_sid_by_script(path)
+  let path = s:_unify_path(a:path)
+  for line in filter(split(s:_redir('scriptnames'), "\n"),
+  \                  'stridx(v:val, s:self_version) > 0')
+    let list = matchlist(line, '^\s*\(\d\+\):\s\+\(.\+\)\s*$')
+    if !empty(list) && s:_unify_path(list[2]) ==# path
+      return list[1] - 0
+    endif
+  endfor
+  return 0
+endfunction
+
+function! s:_file2module(file)
+  let filename = fnamemodify(a:file, ':p:gs?[\\/]\+?/?')
+  let tail = matchstr(filename, 'autoload/vital/_\w\+/\zs.*\ze\.vim$')
+  return join(split(tail, '[\\/]\+'), '.')
+endfunction
+
+if filereadable(expand('<sfile>:r') . '.VIM')
+  " resolve() is slow, so we cache results.
+  let s:_unify_path_cache = {}
+  " Note: On windows, vim can't expand path names from 8.3 formats.
+  " So if getting full path via <sfile> and $HOME was set as 8.3 format,
+  " vital load duplicated scripts. Below's :~ avoid this issue.
+  function! s:_unify_path(path)
+    if has_key(s:_unify_path_cache, a:path)
+      return s:_unify_path_cache[a:path]
+    endif
+    let value = tolower(fnamemodify(resolve(fnamemodify(
+    \                   a:path, ':p')), ':~:gs?[\\/]\+?/?'))
+    let s:_unify_path_cache[a:path] = value
+    return value
+  endfunction
+else
+  function! s:_unify_path(path)
+    return resolve(fnamemodify(a:path, ':p:gs?[\\/]\+?/?'))
+  endfunction
+endif
+
+if s:globpath_third_arg
+  function! s:_runtime_files(path)
+    return split(globpath(&runtimepath, a:path, 1), "\n")
+  endfunction
+else
+  function! s:_runtime_files(path)
+    return split(globpath(&runtimepath, a:path), "\n")
+  endfunction
+endif
+
+let s:_vital_files_cache_runtimepath = ''
+let s:_vital_files_cache = []
+function! s:_vital_files(pattern)
+  if s:_vital_files_cache_runtimepath !=# &runtimepath
+    let path = printf('autoload/vital/%s/**/*.vim', s:self_version)
+    let s:_vital_files_cache = s:_runtime_files(path)
+    let mod = ':p:gs?[\\/]\+?/?'
+    call map(s:_vital_files_cache, 'fnamemodify(v:val, mod)')
+    let s:_vital_files_cache_runtimepath = &runtimepath
+  endif
+  let target = substitute(a:pattern, '\.', '/', 'g')
+  let target = substitute(target, '\*', '[^/]*', 'g')
+  let regexp = printf('autoload/vital/%s/%s.vim', s:self_version, target)
+  return filter(copy(s:_vital_files_cache), 'v:val =~# regexp')
+endfunction
+
+" Copy from System.Filepath
+if has('win16') || has('win32') || has('win64')
+  function! s:_is_absolute_path(path)
+    return a:path =~? '^[a-z]:[/\\]'
+  endfunction
+else
+  function! s:_is_absolute_path(path)
+    return a:path[0] ==# '/'
+  endfunction
+endif
+
+function! s:_build_module(sid)
+  if has_key(s:loaded, a:sid)
+    return copy(s:loaded[a:sid])
+  endif
+  let functions = s:_get_functions(a:sid)
+
+  let prefix = '<SNR>' . a:sid . '_'
+  let module = {}
+  for func in functions
+    let module[func] = function(prefix . func)
+  endfor
+  if has_key(module, '_vital_loaded')
+    let V = vital#{s:self_version}#new()
+    if has_key(module, '_vital_depends')
+      let all = {}
+      let modules =
+      \     s:_concat(map(module._vital_depends(),
+      \                   's:expand_modules(v:val, all)'))
+      call call(V.load, modules, V)
+    endif
+    try
+      call module._vital_loaded(V)
+    catch
+      " FIXME: Show an error message for debug.
+    endtry
+  endif
+  if !get(g:, 'vital_debug', 0)
+    call filter(module, 'v:key =~# "^\\a"')
+  endif
+  let s:loaded[a:sid] = module
+  return copy(module)
+endfunction
+
+if exists('+regexpengine')
+  function! s:_get_functions(sid)
+    let funcs = s:_redir(printf("function /\\%%#=2^\<SNR>%d_", a:sid))
+    let map_pat = '<SNR>' . a:sid . '_\zs\w\+'
+    return map(split(funcs, "\n"), 'matchstr(v:val, map_pat)')
+  endfunction
+else
+  function! s:_get_functions(sid)
+    let prefix = '<SNR>' . a:sid . '_'
+    let funcs = s:_redir('function')
+    let filter_pat = '^\s*function ' . prefix
+    let map_pat = prefix . '\zs\w\+'
+    return map(filter(split(funcs, "\n"),
+    \          'stridx(v:val, prefix) > 0 && v:val =~# filter_pat'),
+    \          'matchstr(v:val, map_pat)')
+  endfunction
+endif
+
+if exists('*uniq')
+  function! s:_uniq(list)
+    return uniq(a:list)
+  endfunction
+else
+  function! s:_uniq(list)
+    let i = len(a:list) - 1
+    while 0 < i
+      if a:list[i] ==# a:list[i - 1]
+        call remove(a:list, i)
+        let i -= 2
+      else
+        let i -= 1
+      endif
+    endwhile
+    return a:list
+  endfunction
+endif
+
+function! s:_concat(lists)
+  let result_list = []
+  for list in a:lists
+    let result_list += list
+  endfor
+  return result_list
+endfunction
+
+function! s:_redir(cmd)
+  let [save_verbose, save_verbosefile] = [&verbose, &verbosefile]
+  set verbose=0 verbosefile=
+  redir => res
+    silent! execute a:cmd
+  redir END
+  let [&verbose, &verbosefile] = [save_verbose, save_verbosefile]
+  return res
+endfunction
+
+function! vital#{s:self_version}#new()
+  return s:_import('')
+endfunction
+
+let s:self_file = s:_unify_path(expand('<sfile>'))

--- a/autoload/vital/_autodirmake/Prelude.vim
+++ b/autoload/vital/_autodirmake/Prelude.vim
@@ -1,0 +1,385 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+if v:version ># 703 ||
+\  (v:version is 703 && has('patch465'))
+  function! s:glob(expr)
+    return glob(a:expr, 1, 1)
+  endfunction
+else
+  function! s:glob(expr)
+    let R = glob(a:expr, 1)
+    return split(R, '\n')
+  endfunction
+endif
+
+function! s:globpath(path, expr)
+  let R = globpath(a:path, a:expr, 1)
+  return split(R, '\n')
+endfunction
+
+" Wrapper functions for type().
+let [
+\   s:__TYPE_NUMBER,
+\   s:__TYPE_STRING,
+\   s:__TYPE_FUNCREF,
+\   s:__TYPE_LIST,
+\   s:__TYPE_DICT,
+\   s:__TYPE_FLOAT] = [
+      \   type(3),
+      \   type(""),
+      \   type(function('tr')),
+      \   type([]),
+      \   type({}),
+      \   has('float') ? type(str2float('0')) : -1]
+" __TYPE_FLOAT = -1 when -float
+" This doesn't match to anything.
+
+" Number or Float
+function! s:is_numeric(Value)
+  let _ = type(a:Value)
+  return _ ==# s:__TYPE_NUMBER
+  \   || _ ==# s:__TYPE_FLOAT
+endfunction
+
+" Number
+function! s:is_number(Value)
+  return type(a:Value) ==# s:__TYPE_NUMBER
+endfunction
+
+" Float
+function! s:is_float(Value)
+  return type(a:Value) ==# s:__TYPE_FLOAT
+endfunction
+" String
+function! s:is_string(Value)
+  return type(a:Value) ==# s:__TYPE_STRING
+endfunction
+" Funcref
+function! s:is_funcref(Value)
+  return type(a:Value) ==# s:__TYPE_FUNCREF
+endfunction
+" List
+function! s:is_list(Value)
+  return type(a:Value) ==# s:__TYPE_LIST
+endfunction
+" Dictionary
+function! s:is_dict(Value)
+  return type(a:Value) ==# s:__TYPE_DICT
+endfunction
+
+function! s:truncate_smart(str, max, footer_width, separator)
+  echoerr 'Prelude.truncate_smart() is obsolete. Use its truncate_skipping() instead; they are equivalent.'
+  return s:truncate_skipping(a:str, a:max, a:footer_width, a:separator)
+endfunction
+
+function! s:truncate_skipping(str, max, footer_width, separator)
+  let width = s:wcswidth(a:str)
+  if width <= a:max
+    let ret = a:str
+  else
+    let header_width = a:max - s:wcswidth(a:separator) - a:footer_width
+    let ret = s:strwidthpart(a:str, header_width) . a:separator
+          \ . s:strwidthpart_reverse(a:str, a:footer_width)
+  endif
+
+  return s:truncate(ret, a:max)
+endfunction
+
+function! s:truncate(str, width)
+  " Original function is from mattn.
+  " http://github.com/mattn/googlereader-vim/tree/master
+
+  if a:str =~# '^[\x00-\x7f]*$'
+    return len(a:str) < a:width ?
+          \ printf('%-'.a:width.'s', a:str) : strpart(a:str, 0, a:width)
+  endif
+
+  let ret = a:str
+  let width = s:wcswidth(a:str)
+  if width > a:width
+    let ret = s:strwidthpart(ret, a:width)
+    let width = s:wcswidth(ret)
+  endif
+
+  if width < a:width
+    let ret .= repeat(' ', a:width - width)
+  endif
+
+  return ret
+endfunction
+
+function! s:strwidthpart(str, width)
+  if a:width <= 0
+    return ''
+  endif
+  let ret = a:str
+  let width = s:wcswidth(a:str)
+  while width > a:width
+    let char = matchstr(ret, '.$')
+    let ret = ret[: -1 - len(char)]
+    let width -= s:wcswidth(char)
+  endwhile
+
+  return ret
+endfunction
+function! s:strwidthpart_reverse(str, width)
+  if a:width <= 0
+    return ''
+  endif
+  let ret = a:str
+  let width = s:wcswidth(a:str)
+  while width > a:width
+    let char = matchstr(ret, '^.')
+    let ret = ret[len(char) :]
+    let width -= s:wcswidth(char)
+  endwhile
+
+  return ret
+endfunction
+
+if v:version >= 703
+  " Use builtin function.
+  function! s:wcswidth(str)
+    return strwidth(a:str)
+  endfunction
+else
+  function! s:wcswidth(str)
+    if a:str =~# '^[\x00-\x7f]*$'
+      return strlen(a:str)
+    end
+
+    let mx_first = '^\(.\)'
+    let str = a:str
+    let width = 0
+    while 1
+      let ucs = char2nr(substitute(str, mx_first, '\1', ''))
+      if ucs == 0
+        break
+      endif
+      let width += s:_wcwidth(ucs)
+      let str = substitute(str, mx_first, '', '')
+    endwhile
+    return width
+  endfunction
+
+  " UTF-8 only.
+  function! s:_wcwidth(ucs)
+    let ucs = a:ucs
+    if (ucs >= 0x1100
+          \  && (ucs <= 0x115f
+          \  || ucs == 0x2329
+          \  || ucs == 0x232a
+          \  || (ucs >= 0x2e80 && ucs <= 0xa4cf
+          \      && ucs != 0x303f)
+          \  || (ucs >= 0xac00 && ucs <= 0xd7a3)
+          \  || (ucs >= 0xf900 && ucs <= 0xfaff)
+          \  || (ucs >= 0xfe30 && ucs <= 0xfe6f)
+          \  || (ucs >= 0xff00 && ucs <= 0xff60)
+          \  || (ucs >= 0xffe0 && ucs <= 0xffe6)
+          \  || (ucs >= 0x20000 && ucs <= 0x2fffd)
+          \  || (ucs >= 0x30000 && ucs <= 0x3fffd)
+          \  ))
+      return 2
+    endif
+    return 1
+  endfunction
+endif
+
+let s:is_windows = has('win16') || has('win32') || has('win64') || has('win95')
+let s:is_cygwin = has('win32unix')
+let s:is_mac = !s:is_windows && !s:is_cygwin
+      \ && (has('mac') || has('macunix') || has('gui_macvim') ||
+      \   (!isdirectory('/proc') && executable('sw_vers')))
+let s:is_unix = has('unix')
+
+function! s:is_windows()
+  return s:is_windows
+endfunction
+
+function! s:is_cygwin()
+  return s:is_cygwin
+endfunction
+
+function! s:is_mac()
+  return s:is_mac
+endfunction
+
+function! s:is_unix()
+  return s:is_unix
+endfunction
+
+function! s:_deprecated2(fname)
+  echomsg printf("Vital.Prelude.%s is deprecated!",
+        \ a:fname)
+endfunction
+
+function! s:smart_execute_command(action, word)
+  execute a:action . ' ' . (a:word == '' ? '' : '`=a:word`')
+endfunction
+
+function! s:escape_file_searching(buffer_name)
+  return escape(a:buffer_name, '*[]?{}, ')
+endfunction
+
+function! s:escape_pattern(str)
+  return escape(a:str, '~"\.^$[]*')
+endfunction
+
+function! s:getchar(...)
+  let c = call('getchar', a:000)
+  return type(c) == type(0) ? nr2char(c) : c
+endfunction
+
+function! s:getchar_safe(...)
+  let c = s:input_helper('getchar', a:000)
+  return type(c) == type("") ? c : nr2char(c)
+endfunction
+
+function! s:input_safe(...)
+  return s:input_helper('input', a:000)
+endfunction
+
+function! s:input_helper(funcname, args)
+  let success = 0
+  if inputsave() !=# success
+    throw 'inputsave() failed'
+  endif
+  try
+    return call(a:funcname, a:args)
+  finally
+    if inputrestore() !=# success
+      throw 'inputrestore() failed'
+    endif
+  endtry
+endfunction
+
+function! s:set_default(var, val)
+  if !exists(a:var) || type({a:var}) != type(a:val)
+    let {a:var} = a:val
+  endif
+endfunction
+
+function! s:set_dictionary_helper(variable, keys, pattern)
+  call s:_deprecated2('set_dictionary_helper')
+
+  for key in split(a:keys, '\s*,\s*')
+    if !has_key(a:variable, key)
+      let a:variable[key] = a:pattern
+    endif
+  endfor
+endfunction
+
+function! s:substitute_path_separator(path)
+  return s:is_windows ? substitute(a:path, '\\', '/', 'g') : a:path
+endfunction
+
+function! s:path2directory(path)
+  return s:substitute_path_separator(isdirectory(a:path) ? a:path : fnamemodify(a:path, ':p:h'))
+endfunction
+
+function! s:_path2project_directory_git(path)
+  let parent = a:path
+
+  while 1
+    let path = parent . '/.git'
+    if isdirectory(path) || filereadable(path)
+      return parent
+    endif
+    let next = fnamemodify(parent, ':h')
+    if next == parent
+      return ''
+    endif
+    let parent = next
+  endwhile
+endfunction
+
+function! s:_path2project_directory_svn(path)
+  let search_directory = a:path
+  let directory = ''
+
+  let find_directory = s:escape_file_searching(search_directory)
+  let d = finddir('.svn', find_directory . ';')
+  if d == ''
+    return ''
+  endif
+
+  let directory = fnamemodify(d, ':p:h:h')
+
+  " Search parent directories.
+  let parent_directory = s:path2directory(
+        \ fnamemodify(directory, ':h'))
+
+  if parent_directory != ''
+    let d = finddir('.svn', parent_directory . ';')
+    if d != ''
+      let directory = s:_path2project_directory_svn(parent_directory)
+    endif
+  endif
+  return directory
+endfunction
+
+function! s:_path2project_directory_others(vcs, path)
+  let vcs = a:vcs
+  let search_directory = a:path
+
+  let find_directory = s:escape_file_searching(search_directory)
+  let d = finddir(vcs, find_directory . ';')
+  if d == ''
+    return ''
+  endif
+  return fnamemodify(d, ':p:h:h')
+endfunction
+
+function! s:path2project_directory(path, ...)
+  let is_allow_empty = get(a:000, 0, 0)
+  let search_directory = s:path2directory(a:path)
+  let directory = ''
+
+  " Search VCS directory.
+  for vcs in ['.git', '.bzr', '.hg', '.svn']
+    if vcs ==# '.git'
+      let directory = s:_path2project_directory_git(search_directory)
+    elseif vcs ==# '.svn'
+      let directory = s:_path2project_directory_svn(search_directory)
+    else
+      let directory = s:_path2project_directory_others(vcs, search_directory)
+    endif
+    if directory != ''
+      break
+    endif
+  endfor
+
+  " Search project file.
+  if directory == ''
+    for d in ['build.xml', 'prj.el', '.project', 'pom.xml', 'package.json',
+          \ 'Makefile', 'configure', 'Rakefile', 'NAnt.build',
+          \ 'P4CONFIG', 'tags', 'gtags']
+      let d = findfile(d, s:escape_file_searching(search_directory) . ';')
+      if d != ''
+        let directory = fnamemodify(d, ':p:h')
+        break
+      endif
+    endfor
+  endif
+
+  if directory == ''
+    " Search /src/ directory.
+    let base = s:substitute_path_separator(search_directory)
+    if base =~# '/src/'
+      let directory = base[: strridx(base, '/src/') + 3]
+    endif
+  endif
+
+  if directory == '' && !is_allow_empty
+    " Use original path.
+    let directory = search_directory
+  endif
+
+  return s:substitute_path_separator(directory)
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim:set et ts=2 sts=2 sw=2 tw=0:

--- a/autoload/vital/autodirmake.vital
+++ b/autoload/vital/autodirmake.vital
@@ -1,0 +1,4 @@
+autodirmake
+a9aa86b
+
+Prelude


### PR DESCRIPTION
すみません、 #1 のブランチから派生してます。

vim-jp/vital.vim#183 で言った通り、
ファイルパスをコマンドラインに収まるように
いい感じに省略する機能を追加しました。
(しかしちなみに vim-jp/vital.vim#183 で追加した関数は結局使いませんでした…)
