### PR TITLE
Add g:autodirmake#char_prompt

### DIFF
--- a/autoload/autodirmake.vim
+++ b/autoload/autodirmake.vim
@@ -10,6 +10,7 @@ set cpo&vim
 
 let g:autodirmake#is_confirm = get(g:, 'autodirmake#is_confirm', 1)
 let g:autodirmake#msg_highlight = get(g:, 'autodirmake#msg_highlight', 'None')
+let g:autodirmake#char_prompt = get(g:, 'autodirmake#char_prompt', 0)
 
 
 let s:V = vital#of('autodirmake')
@@ -47,12 +48,34 @@ function! s:confirm(dir)
             let footer_width = strlen(fnamemodify(a:dir, ':t')) + 1
             let abbrdir = s:Prelude.truncate_skipping(abbrdir, maxlen - 3, footer_width, '...')
         endif
-        return input(printf(prompt, abbrdir)) =~? '^y\%[es]$'
+        return s:prompt(printf(prompt, abbrdir)) =~? '^y\%[es]$'
     finally
         if hl !=# '' && hl !=# 'None'
             echohl None
         endif
     endtry
+endfunction
+
+function! s:prompt(msg)
+    if !g:autodirmake#char_prompt
+        return input(a:msg)
+    else
+        echo a:msg
+        while 1
+            let char = s:getchar()
+            if char ==? 'y' || char ==? 'n'
+                return char
+            else
+                echo "Please type either 'y' or 'n'."
+                echo a:msg
+            endif
+        endwhile
+    endif
+endfunction
+
+function! s:getchar(...)
+  let c = call('getchar', a:000)
+  return type(c) == type(0) ? nr2char(c) : c
 endfunction
 
 

--- a/autoload/autodirmake.vim
+++ b/autoload/autodirmake.vim
@@ -32,12 +32,7 @@ function! s:confirm(dir)
     if !g:autodirmake#is_confirm
         return 1
     endif
-
-    let hl = g:autodirmake#msg_highlight
-    if hl !=# '' && hl !=# 'None'
-        execute 'echohl' hl
-    endif
-
+    call s:apply_msg_highlight()
     try
         let prompt = '"%s" does not exist. Create? [y/N]'
         let maxlen = &columns - 1
@@ -50,10 +45,15 @@ function! s:confirm(dir)
         endif
         return s:prompt(printf(prompt, abbrdir)) =~? '^y\%[es]$'
     finally
-        if hl !=# '' && hl !=# 'None'
-            echohl None
-        endif
+        echohl None
     endtry
+endfunction
+
+function! s:apply_msg_highlight()
+    let hl = g:autodirmake#msg_highlight
+    if hl !=# '' && hl !=# 'None'
+        execute 'echohl' hl
+    endif
 endfunction
 
 function! s:prompt(msg)
@@ -66,7 +66,9 @@ function! s:prompt(msg)
             if char ==? 'y' || char ==? 'n'
                 return char
             else
+                echohl WarningMsg
                 echo "Please type either 'y' or 'n'."
+                call s:apply_msg_highlight()
                 echo a:msg
             endif
         endwhile


### PR DESCRIPTION
`g:autodirmake#char_prompt` を追加しました。
この変数は、0以外の値だとプロンプトを出す時に
`input()`ではなく`getchar()`を使うようになります。
よってエンターを押す必要がなくなります。

ちなみに、「y」「Y」「n」「N」以外を押すと
`Please type either 'y' or 'n'.` と聞き返します。

また、互換性のため、デフォルトでは有効にしていません。